### PR TITLE
No need to have a minified babel plugin

### DIFF
--- a/packages/reactor-babel-plugin/package.json
+++ b/packages/reactor-babel-plugin/package.json
@@ -2,7 +2,7 @@
   "name": "@extjs/reactor-babel-plugin",
   "version": "0.2.9",
   "description": "Converts ES6 imports to reactify calls.",
-  "main": "dist/reactor-babel-plugin.min.js",
+  "main": "dist/reactor-babel-plugin.js",
   "module": "index.js",
   "scripts": {
     "build": "webpack",

--- a/packages/reactor-babel-plugin/webpack.config.js
+++ b/packages/reactor-babel-plugin/webpack.config.js
@@ -5,7 +5,7 @@ const config = {
     entry: './src/index.js',
     output: {
         path: path.join(__dirname, './dist'),
-        filename: 'reactor-babel-plugin.min.js',
+        filename: 'reactor-babel-plugin.js',
         library: 'ReactorBabelPlugin',
         libraryTarget: 'umd',
         umdNamedDefine: true
@@ -16,14 +16,7 @@ const config = {
             loader: 'babel-loader',
             exclude: /node_modules/
         }]
-    },
-    plugins: [
-        new webpack.optimize.UglifyJsPlugin({
-            compress: {
-                warnings: false
-            }
-        })
-    ]
+    }
 }
 
 module.exports = config;


### PR DESCRIPTION
Babel running in node doesn't need to be minified. For fiddle usage, let fiddle deal with minification (which is only wanted in prod, not test).