### PR TITLE
fix docs link for @extjs/reactor-classic-boilerplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ This is a monorepo that uses lerna.  After cloning, run `npm install` then `lern
 * [@extjs/reactor-webpack-plugin](https://github.com/sencha/extjs-reactor/tree/master/packages/reactor-webpack-plugin) - Integrates Webpack with Sencha Cmd to produce optimized builds of Ext JS
 * [@extjs/reactor-babel-plugin](https://github.com/sencha/extjs-reactor/tree/master/packages/reactor-babel-plugin) - Allows you to load reactified Ext JS components using ES6 import syntax.
 * [@extjs/reactor-boilerplate](https://github.com/sencha/extjs-reactor/tree/master/packages/reactor-boilerplate) - An example project using React, Webpack, and Ext JS 6 with the modern toolkit.
-* [@extjs/reactor-classic-boilerplate](https://github.com/sencha/extjs-reactor/tree/master/packages/reactor-boilerplate) - An example project using React, Webpack, and Ext JS 6 with the classic toolkit.
+* [@extjs/reactor-classic-boilerplate](https://github.com/sencha/extjs-reactor/tree/master/packages/reactor-classic-boilerplate) - An example project using React, Webpack, and Ext JS 6 with the classic toolkit.
 
 # Contributing
 


### PR DESCRIPTION
just fixing documentation link for @extjs/reactor-classic-boilerplate