### PR TITLE
Pipe sencha-cmd stderr to stderr and prevent an undefined pointer

### DIFF
--- a/packages/reactor-webpack-plugin/src/index.js
+++ b/packages/reactor-webpack-plugin/src/index.js
@@ -309,9 +309,10 @@ module.exports = class ReactExtJSWebpackPlugin {
             if (this.watch) {
                 if (!watching) {
                     watching = fork(sencha, ['ant', 'watch'], { cwd: output, silent: true });
+                    watching.stderr.pipe(process.stderr);
                     watching.stdout.pipe(process.stdout);
                     watching.stdout.on('data', data => {
-                        if (data.toString().match(/Waiting for changes\.\.\./)) {
+                        if (data && data.toString().match(/Waiting for changes\.\.\./)) {
                             this.onBuildComplete(output);
                         }
                     });
@@ -322,6 +323,7 @@ module.exports = class ReactExtJSWebpackPlugin {
             } else {
                 const build = fork(sencha, ['ant', 'build'], { cwd: output, silent: true });
                 build.stdout.pipe(process.stdout);
+                build.stderr.pipe(process.stderr);
                 build.on('exit', () => resolve(output));
             }
         });


### PR DESCRIPTION
When an error ocurred during the execution of Sencha Cmd as a child process, stderr was not displayed (which would help identify the root cause).

Futhermore, there was a pontentially undefined variable `data` that resulted in a misleading error message (`Can't read property toString of undefined`).