### PR TITLE
Move state instantiation to the constructor

### DIFF
--- a/packages/reactor-boilerplate/src/Layout.js
+++ b/packages/reactor-boilerplate/src/Layout.js
@@ -11,8 +11,12 @@ import NavMenu from './NavMenu';
  */
 class Layout extends Component {
 
-    state = {
-        showAppMenu: false
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            showAppMenu: false
+        }
     }
 
     toggleAppMenu = () => {


### PR DESCRIPTION
I'd like to suggest moving the state instantiation to the constructor. 

https://facebook.github.io/react/docs/state-and-lifecycle.html#adding-local-state-to-a-class

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- extjs-reactor only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of `extjs-reactor`.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
