### PR TITLE
Make sure ext-react* and sencha-cmd* packages are updated

### DIFF
--- a/scripts/next.js
+++ b/scripts/next.js
@@ -15,7 +15,7 @@ function updateToNext(dir) {
         if (!packageInfo.dependencies) return;
 
         const extReactPackages = Object.keys(packageInfo.dependencies)
-            .filter(name => name.match(/@extjs\/(ext-react|sencha-cmd)/))
+            .filter(name => name.match(/@extjs\/(ext-react|sencha-cmd).*/))
             .map(name => `${name}@next`)
 
         if (extReactPackages.length) {


### PR DESCRIPTION
## Description
This PR updates `scripts/next.js` in order to include subpackages of `ext-react`. This was discovered while testing `reactor-kitchensink` which lists several `ext-react-*` packages that were left behind when running `install:next`.

## How Has This Been Tested?
Tested locally and on CI environment (directly ran the contents of the updated file as build step).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of `extjs-reactor`.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
