### PR TITLE
Fix for Kitchen Sink not opening on in IE 

### DIFF
--- a/packages/reactor-kitchensink16/webpack.config.js
+++ b/packages/reactor-kitchensink16/webpack.config.js
@@ -89,7 +89,7 @@ module.exports = function (env) {
         context: sourcePath,
 
         entry: {
-            vendor: ['react', 'prop-types', 'react-redux', 'react-dom', 'react-router-dom', 'history', 'redux', 'd3', 'highlightjs'],
+            vendor: ['babel-polyfill', 'react', 'prop-types', 'react-redux', 'react-dom', 'react-router-dom', 'history', 'redux', 'd3', 'highlightjs'],
             app: './index.js'
         },
 


### PR DESCRIPTION
'Objects are not valid as a React child' error in IE

