### PR TITLE
[ext-gen] Log the output of npm install

### DIFF
--- a/packages/ext-gen/ext-gen.js
+++ b/packages/ext-gen/ext-gen.js
@@ -292,7 +292,7 @@ async function stepCreate() {
 
   try {
     console.log(chalk.green('NPM install started...'));
-    await util.spawnPromise('npm.cmd', ['install']);
+    await util.spawnPromise('npm.cmd', ['install'], { stdio: 'inherit', encoding: 'utf-8' });
     console.log(chalk.green('NPM install completed.'));
   }catch(err) {
     console.log(chalk.red('Error in NPM install: ' + err));


### PR DESCRIPTION
The output from the spawned child should be logged to the console.

![image](https://user-images.githubusercontent.com/25049547/40037769-95ebc1d0-582c-11e8-8a76-796da97dff47.png)
