### PR TITLE
ext-build: pass options to buildAsync

### DIFF
--- a/packages/ext-build/bin/ext-build.js
+++ b/packages/ext-build/bin/ext-build.js
@@ -75,7 +75,7 @@ const optionDefinitions = [
         case 'build': case 'b':
           var build = require('../app/buildAsync.js')
           //new build(options)
-          new build().executeAsync().then(function() {})
+          new build(options).executeAsync().then(function() {})
           break;
         case 'refresh': case 'r':
           var refresh = require('../app/refresh.js')


### PR DESCRIPTION
`npm run buildtest` was not able to run because of this
