### PR TITLE
Get theme name from sencha section of package.json

### DIFF
--- a/packages/reactor-webpack-plugin/src/artifacts.js
+++ b/packages/reactor-webpack-plugin/src/artifacts.js
@@ -151,7 +151,8 @@ export function createAppJson({ theme, packages, toolkit, overrides=[], packageD
     // if theme is local add it as an additional package dir
     if (fs.existsSync(theme)) {
         const packageInfo = cjson.load(path.join(theme, 'package.json'));
-        config.theme = packageInfo.name;
+        // get theme name from sencha section if it exists
+        config.theme = (packageInfo.sencha && packageInfo.sencha.name) || packageInfo.name;
         config.packages.dir.push(path.resolve(theme));
     } else {
         config.theme = theme;
@@ -162,7 +163,7 @@ export function createAppJson({ theme, packages, toolkit, overrides=[], packageD
 
 /**
  * Creates a js file containing code to make Ext JS load properly in jsdom
- * @param {String} targetDir 
+ * @param {String} targetDir
  */
 export function createJSDOMEnvironment(targetDir) {
     return 'window.Ext = Ext;';


### PR DESCRIPTION
## Description
Allow to use themes from scoped npm packages  

## Related Issue
<!--- extjs-reactor only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We npm for distributing extjs themes and packages. 
It works well with ExtJS apps, but not with ext-reactor since reactor-webpack-plugin only gets theme name from the root of package.json, not from sencha section. 

This causes compilation errors such as following:
```
Failed to compile.
[@extjs/reactor-webpack-plugin]: Error: 
BUILD FAILED
com.sencha.exceptions.BasicException: com.sencha.exceptions.ExParse: Not a valid name/version "@scope/my-custom-theme"

```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally by building ext-reactor app with @scope/my-custom-theme as a theme.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of `extjs-reactor`.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
