### PR TITLE
Yoeman issue resolved

### DIFF
--- a/packages/generator-ext-react/generators/app/index.js
+++ b/packages/generator-ext-react/generators/app/index.js
@@ -18,8 +18,8 @@ const LANGUAGE = {
 };
 
 const REACTVERSION = {
-    REACT15: 15,
-    REACT16: 16
+    REACT15: '15',
+    REACT16: '16'
 };
 
 const BOILERPLATE = {

--- a/packages/reactor-boilerplate15/ext-react/overrides/README.md
+++ b/packages/reactor-boilerplate15/ext-react/overrides/README.md
@@ -1,0 +1,3 @@
+# Ext JS Overrides
+
+Ext JS overrides go here. This is configured in webpack.config.js.

--- a/packages/reactor-boilerplate15/ext-react/packages/README.md
+++ b/packages/reactor-boilerplate15/ext-react/packages/README.md
@@ -1,0 +1,3 @@
+# packages
+
+Custom themes and other third-party Ext JS packages go here.

--- a/packages/reactor-boilerplate15/ext-react/packages/custom-ext-react-theme/Readme.md
+++ b/packages/reactor-boilerplate15/ext-react/packages/custom-ext-react-theme/Readme.md
@@ -1,0 +1,2 @@
+# custom-ext-react-theme - Read Me
+

--- a/packages/reactor-boilerplate15/ext-react/packages/custom-ext-react-theme/build.xml
+++ b/packages/reactor-boilerplate15/ext-react/packages/custom-ext-react-theme/build.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<project name="custom-ext-react-theme" default=".help">
+
+    <script language="javascript">
+        <![CDATA[
+            var dir = project.getProperty("basedir"),
+                cmdDir = project.getProperty("cmd.dir"),
+                cmdLoaded = project.getReference("senchaloader");
+
+            if (!cmdLoaded) {
+                function echo(message, file) {
+                    var e = project.createTask("echo");
+                    e.setMessage(message);
+                    if (file) {
+                        e.setFile(file);
+                    }
+                    e.execute();
+                };
+
+                if (!cmdDir) {
+
+                    function exec(args) {
+                        var process = java.lang.Runtime.getRuntime().exec(args),
+                            input = new java.io.BufferedReader(new java.io.InputStreamReader(process.getInputStream())),
+                            headerFound = false,
+                            line;
+
+                        while (line = input.readLine()) {
+                            line = line + '';
+                            java.lang.System.out.println(line);
+                            if (line.indexOf("Sencha Cmd") > -1) {
+                                headerFound = true;
+                            }
+                            else if (headerFound && !cmdDir) {
+                                cmdDir = line;
+                                project.setProperty("cmd.dir", cmdDir);
+                            }
+                        }
+                        process.waitFor();
+                        return !!cmdDir;
+                    }
+
+                    if (!exec(["sencha", "which"])) {
+                        var tmpFile = "tmp.sh";
+                        echo("source ~/.bash_profile; sencha " + whichArgs.join(" "), tmpFile);
+                        exec(["/bin/sh", tmpFile]);
+                        new java.io.File(tmpFile)['delete'](); 
+                    }
+                }
+            }
+
+            if (cmdDir && !project.getTargets().containsKey("init-cmd")) {
+                var importDir = project.getProperty("build-impl.dir") || 
+                                (cmdDir + "/ant/build/package/build-impl.xml");
+                var importTask = project.createTask("import");
+
+                importTask.setOwningTarget(self.getOwningTarget());
+                importTask.setLocation(self.getLocation());
+                importTask.setFile(importDir);
+                importTask.execute();
+            }
+        ]]>
+    </script>
+
+    <!--
+    The following targets can be provided to inject logic before and/or after key steps
+    of the build process:
+
+        The "init-local" target is used to initialize properties that may be personalized
+        for the local machine.
+
+            <target name="-before-init-local"/>
+            <target name="-after-init-local"/>
+
+        The "clean" target is used to clean build output from the build.dir.
+
+            <target name="-before-clean"/>
+            <target name="-after-clean"/>
+
+        The general "init" target is used to initialize all other properties, including
+        those provided by Sencha Cmd.
+
+            <target name="-before-init"/>
+            <target name="-after-init"/>
+
+        The "build" target performs the call to Sencha Cmd to build the application.
+
+            <target name="-before-build"/>
+            <target name="-after-build"/>
+    -->
+
+</project>

--- a/packages/reactor-boilerplate15/ext-react/packages/custom-ext-react-theme/examples/Readme.md
+++ b/packages/reactor-boilerplate15/ext-react/packages/custom-ext-react-theme/examples/Readme.md
@@ -1,0 +1,38 @@
+# custom-ext-react-theme/examples
+
+This folder contains example applications demonstrating this package. Each of
+these applications will be built as part of the package build:
+
+    cd /path/to/package
+    sencha package build
+
+As applications, they can also be built individually:
+
+    cd /path/to/package/examples/example-app
+    sencha app build
+
+Or you can build all examples as a group:
+
+    cd /path/to/package
+    sencha ant examples
+
+The ideal location for the example builds to reside is the `"./build"` folder:
+
+    /path/to/package/
+        src/
+        resources/
+        ...
+        examples/
+            example-app/
+            other-example/
+        ...
+        build/
+            resources/
+            examples/
+                example-app/
+                other-example/
+
+This can be specified in the `".sencha/app/build.properties"` file for the
+example applications:
+
+    build.dir=${package.build.dir}/examples/${app.name}

--- a/packages/reactor-boilerplate15/ext-react/packages/custom-ext-react-theme/licenses/Readme.md
+++ b/packages/reactor-boilerplate15/ext-react/packages/custom-ext-react-theme/licenses/Readme.md
@@ -1,0 +1,3 @@
+# custom-ext-react-theme/licenses
+
+This folder contains the supported licenses for third-party use.

--- a/packages/reactor-boilerplate15/ext-react/packages/custom-ext-react-theme/overrides/Readme.md
+++ b/packages/reactor-boilerplate15/ext-react/packages/custom-ext-react-theme/overrides/Readme.md
@@ -1,0 +1,3 @@
+# custom-ext-react-theme/overrides
+
+This folder contains overrides which will automatically be required by package users.

--- a/packages/reactor-boilerplate15/ext-react/packages/custom-ext-react-theme/overrides/init.js
+++ b/packages/reactor-boilerplate15/ext-react/packages/custom-ext-react-theme/overrides/init.js
@@ -1,0 +1,2 @@
+Ext.namespace('Ext.theme.is')['custom-ext-react-theme'] = true;
+Ext.theme.name = 'custom-ext-react-theme';

--- a/packages/reactor-boilerplate15/ext-react/packages/custom-ext-react-theme/package.json
+++ b/packages/reactor-boilerplate15/ext-react/packages/custom-ext-react-theme/package.json
@@ -1,0 +1,279 @@
+{
+    /**
+     * The name of the package.
+     */
+    "name": "custom-ext-react-theme",
+
+    "sencha": {
+        /**
+         * Alternate names for this package.
+         *
+         *    "alternateName": [],
+         */
+
+         /**
+          * The namespace of this package.
+          *
+          * As a general rule, all classes that belong to this package should be under this namespace
+          * if multiple namespaces are part of this package, set this to "".
+          */
+         "namespace": "Ext",
+
+        /**
+         * The package type.
+         *
+         * Sencha Cmd understands the following types of packages:
+         *  - code : An arbitrary package of code for use by applications or other packages.
+         *  - theme : A package to be used as an application’s theme.
+         *  - locale : A package containing localization strings or locale-specific code.
+         *  - template : A package containing one or more templates.
+         */
+        "type": "theme",
+
+        /**
+         * The parent theme package (only for "theme" package type).
+         *
+         * Themes can also use extend to inherit Sass and resources from another theme package.
+         *
+         *    "extend": "parent-theme-package",
+         */
+        "extend": "theme-material",
+
+        /**
+         * The toolkit used by this theme (only for "theme" package type).
+         *
+         * Themes can specify the toolkit they apply to ("classic" or "modern").
+         *
+         *    "toolkit": "classic",
+         */
+        "toolkit": "",
+
+         /**
+          * The author of the package.
+          *
+          * Required only if you are distributing this package through a Sencha Cmd repository,
+          * in which case it should match the name you assign to your local package repository.
+          */
+        "creator": "anonymous",
+
+        /**
+         * A summarized description of this package.
+         */
+        "summary": "Short summary",
+
+        /**
+         * A detailed description of this package.
+         */
+        "detailedDescription": "Long description of package",
+
+        /**
+         * The package version.
+         *
+         * Typically, changes to the package should come along with changes to the version.
+         * This number should be in this format: d+(.d+)*
+         */
+        "version": "1.0.0",
+
+        /**
+         * The version that users can transparently update from without requiring code changes.
+         *
+         * In addition the version property, packages can also indicate the degree to which
+         * they are backward compatible using the compatVersion property.
+         */
+        "compatVersion": "1.0.0",
+
+        /**
+         * Spec. version of this package.json file.
+         * This is set automatically by Sencha Cmd when first generating this file
+         */
+        "format": "1",
+
+        /**
+         * Additional resources used during theme slicing operations
+         */
+        "slicer": {
+            "js": [
+                {
+                    "path": "${package.dir}/sass/example/custom.js",
+                    "isWidgetManifest": true
+                }
+            ]
+        },
+
+        /**
+         * Controls the output directory.
+         */
+        "output": "${package.dir}/build",
+
+        /**
+         * Indicates whether this is a locally developed package or downloaded form a repository.
+         * Defaults to true on newly generated packages, should not be changed.
+         */
+        "local": true,
+
+        /**
+         * The theme (package) this package will use (e.g., "ext-theme-neptune", etc.).
+         * This is only needed if the built package will be used by a non-Cmd application.
+         *
+         *     "theme": "ext-theme-classic",
+         */
+
+        /**
+         * Sass configuration properties.
+         */
+        "sass" : {
+            /**
+             * The namespace to which this package's SASS corresponds. The default value of
+             * "Ext" means that the files in ./sass/src (and ./sass/var) match classes in
+             * the Ext" root namespace. In other words, "Ext.panel.Panel" maps to
+             * ./sass/src/panel/Panel.scss.
+             *
+             * To style classes from any namespace, set this to blank. If this is blank,
+             * then to style "Ext.panel.Panel" you would put SASS in
+             * ./sass/src/Ext/panel/Panel.scss.
+             */
+            "namespace": "",
+
+            /**
+             * Comma-separated list of files or folders containing extra Sass. These
+             * files are automatically included in the Sass compilation. By default this
+             * is just "etc/all.scss" to allow import directives to control the order
+             * other files are included.
+             *
+             * All "etc" files are included at the top of the Sass compilation in their
+             * dependency order:
+             *
+             *      +-------+---------+
+             *      |       | base    |
+             *      | theme +---------+
+             *      |       | derived |
+             *      +-------+---------+
+             *      | packages        |  (in package dependency order)
+             *      +-----------------+
+             *      | application     |
+             *      +-----------------+
+             */
+            "etc": [
+                "${package.dir}/sass/etc/all.scss"
+             ],
+
+            /**
+             * Comma-separated list of folders containing Sass variable definitions
+             * files. These file can also define Sass mixins for use by components.
+             *
+             * All "var" files are included after "etc" files in the Sass compilation in
+             * dependency order:
+             *
+             *      +-------+---------+
+             *      |       | base    |
+             *      | theme +---------+
+             *      |       | derived |
+             *      +-------+---------+
+             *      | packages        |  (in package dependency order)
+             *      +-----------------+
+             *      | application     |
+             *      +-----------------+
+             *
+             * The "sass/var/all.scss" file is always included at the start of the var
+             * block before any files associated with JavaScript classes.
+             */
+            "var": [
+                "${package.dir}/sass/var"
+            ],
+
+            /**
+             * Comma-separated list of folders containing Sass rule files.
+             *
+             * All "src" files are included after "var" files in the Sass compilation in
+             * dependency order (the same order as "etc"):
+             *
+             *      +-------+---------+
+             *      |       | base    |
+             *      | theme +---------+
+             *      |       | derived |
+             *      +-------+---------+
+             *      | packages        |  (in package dependency order)
+             *      +-----------------+
+             *      | application     |
+             *      +-----------------+
+             */
+            "src": [
+                "${package.dir}/sass/src"
+            ]
+        },
+
+        /**
+         * This is the comma-separated list of folders where classes reside. These
+         * classes must be explicitly required to be included in the build.
+         */
+        "classpath": [
+            "${package.dir}/src"
+        ],
+
+        /**
+         * Comma-separated string with the paths of directories or files to search. Any classes
+         * declared in these locations will be automatically required and included in the build.
+         * If any file defines an Ext JS override (using Ext.define with an "override" property),
+         * that override will in fact only be included in the build if the target class specified
+         * in the "override" property is also included.
+         */
+        "overrides": [
+            "${package.dir}/overrides"
+        ],
+
+        "example": {
+            /**
+             * One or more folders that contain example applications for this package.
+             */
+            "path": [
+                "${package.dir}/examples"
+            ]
+
+            /**
+             * You can list apps specifically.
+             *
+             *      "apps": [
+             *          "demo1",
+             *          "demo2"
+             *      ]
+             *
+             * By default, all subfolders in the path are considered example applications.
+             */
+        },
+
+        /**
+         * The framework this package will use (i.e., "ext" or "touch").
+         * This is only needed if the built package will be used by a non-Cmd application.
+         *
+         *     "framework": "ext",
+         */
+        "framework": "--name",
+
+        /**
+         * Packages can require other packages in the same way that applications can require
+         * packages.
+         *
+         * Can be specified as an array of package names or configuration objects.
+         *
+         *      "requires": [
+         *          "foo",
+         *          "bar@1.1-2.0",
+         *          {
+         *              "name": "baz"
+         *              "version": "1.5"
+         *          }
+         *      ]
+         *
+         * Can also be specified as an object:
+         *
+         *      "requires": {
+         *          "foo": "2.2",
+         *          "bar": {
+         *              "minVersion": "1.1",
+         *              "version": "2.0"
+         *          }
+         *      }
+         */
+        "requires": []
+    }
+}

--- a/packages/reactor-boilerplate15/ext-react/packages/custom-ext-react-theme/resources/Readme.md
+++ b/packages/reactor-boilerplate15/ext-react/packages/custom-ext-react-theme/resources/Readme.md
@@ -1,0 +1,3 @@
+# custom-ext-react-theme/resources
+
+This folder contains static resources (typically an `"images"` folder as well).

--- a/packages/reactor-boilerplate15/ext-react/packages/custom-ext-react-theme/sass/Readme.md
+++ b/packages/reactor-boilerplate15/ext-react/packages/custom-ext-react-theme/sass/Readme.md
@@ -1,0 +1,7 @@
+# custom-ext-react-theme/sass
+
+This folder contains SASS files of various kinds, organized in sub-folders:
+
+    custom-ext-react-theme/sass/etc
+    custom-ext-react-theme/sass/src
+    custom-ext-react-theme/sass/var

--- a/packages/reactor-boilerplate15/ext-react/packages/custom-ext-react-theme/sass/config.rb
+++ b/packages/reactor-boilerplate15/ext-react/packages/custom-ext-react-theme/sass/config.rb
@@ -1,0 +1,2 @@
+cur_dir = File.dirname(__FILE__)
+output_style = :nested

--- a/packages/reactor-boilerplate15/ext-react/packages/custom-ext-react-theme/sass/etc/Readme.md
+++ b/packages/reactor-boilerplate15/ext-react/packages/custom-ext-react-theme/sass/etc/Readme.md
@@ -1,0 +1,4 @@
+# custom-ext-react-theme/sass/etc
+
+This folder contains miscellaneous SASS files. Unlike `"custom-ext-react-theme/sass/etc"`, these files
+need to be used explicitly.

--- a/packages/reactor-boilerplate15/ext-react/packages/custom-ext-react-theme/sass/src/Readme.md
+++ b/packages/reactor-boilerplate15/ext-react/packages/custom-ext-react-theme/sass/src/Readme.md
@@ -1,0 +1,4 @@
+# custom-ext-react-theme/sass/src
+
+This folder contains SASS sources that mimic the component-class hierarchy. These files
+are gathered in to a build of the CSS based on classes that are used by the build.

--- a/packages/reactor-boilerplate15/ext-react/packages/custom-ext-react-theme/sass/var/Readme.md
+++ b/packages/reactor-boilerplate15/ext-react/packages/custom-ext-react-theme/sass/var/Readme.md
@@ -1,0 +1,3 @@
+# custom-ext-react-theme/sass/var
+
+This folder contains variable declaration files named by their component class.

--- a/packages/reactor-boilerplate15/ext-react/packages/custom-ext-react-theme/src/Readme.md
+++ b/packages/reactor-boilerplate15/ext-react/packages/custom-ext-react-theme/src/Readme.md
@@ -1,0 +1,4 @@
+# custom-ext-react-theme/src
+
+This folder contains source code that will automatically be added to the classpath when
+the package is used.

--- a/packages/reactor-boilerplate15/ext-react/workspace.json
+++ b/packages/reactor-boilerplate15/ext-react/workspace.json
@@ -1,0 +1,15 @@
+{
+    "apps": [],
+    "frameworks": {
+        "ext": "../node_modules/@extjs/ext-react"
+    },
+    "build": {
+        "dir": "${workspace.dir}/build"
+    },
+    "packages": {
+        "dir": "${workspace.dir}/packages,${workspace.dir}/../node_modules/@extjs"
+    },
+    "properties": {
+        "build.web.root": "${workspace.dir}/../"
+    }
+}

--- a/packages/reactor-boilerplate16/ext-react/overrides/README.md
+++ b/packages/reactor-boilerplate16/ext-react/overrides/README.md
@@ -1,0 +1,3 @@
+# Ext JS Overrides
+
+Ext JS overrides go here. This is configured in webpack.config.js.

--- a/packages/reactor-boilerplate16/ext-react/packages/README.md
+++ b/packages/reactor-boilerplate16/ext-react/packages/README.md
@@ -1,0 +1,3 @@
+# packages
+
+Custom themes and other third-party Ext JS packages go here.

--- a/packages/reactor-boilerplate16/ext-react/packages/custom-ext-react-theme/Readme.md
+++ b/packages/reactor-boilerplate16/ext-react/packages/custom-ext-react-theme/Readme.md
@@ -1,0 +1,2 @@
+# custom-ext-react-theme - Read Me
+

--- a/packages/reactor-boilerplate16/ext-react/packages/custom-ext-react-theme/build.xml
+++ b/packages/reactor-boilerplate16/ext-react/packages/custom-ext-react-theme/build.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<project name="custom-ext-react-theme" default=".help">
+
+    <script language="javascript">
+        <![CDATA[
+            var dir = project.getProperty("basedir"),
+                cmdDir = project.getProperty("cmd.dir"),
+                cmdLoaded = project.getReference("senchaloader");
+
+            if (!cmdLoaded) {
+                function echo(message, file) {
+                    var e = project.createTask("echo");
+                    e.setMessage(message);
+                    if (file) {
+                        e.setFile(file);
+                    }
+                    e.execute();
+                };
+
+                if (!cmdDir) {
+
+                    function exec(args) {
+                        var process = java.lang.Runtime.getRuntime().exec(args),
+                            input = new java.io.BufferedReader(new java.io.InputStreamReader(process.getInputStream())),
+                            headerFound = false,
+                            line;
+
+                        while (line = input.readLine()) {
+                            line = line + '';
+                            java.lang.System.out.println(line);
+                            if (line.indexOf("Sencha Cmd") > -1) {
+                                headerFound = true;
+                            }
+                            else if (headerFound && !cmdDir) {
+                                cmdDir = line;
+                                project.setProperty("cmd.dir", cmdDir);
+                            }
+                        }
+                        process.waitFor();
+                        return !!cmdDir;
+                    }
+
+                    if (!exec(["sencha", "which"])) {
+                        var tmpFile = "tmp.sh";
+                        echo("source ~/.bash_profile; sencha " + whichArgs.join(" "), tmpFile);
+                        exec(["/bin/sh", tmpFile]);
+                        new java.io.File(tmpFile)['delete'](); 
+                    }
+                }
+            }
+
+            if (cmdDir && !project.getTargets().containsKey("init-cmd")) {
+                var importDir = project.getProperty("build-impl.dir") || 
+                                (cmdDir + "/ant/build/package/build-impl.xml");
+                var importTask = project.createTask("import");
+
+                importTask.setOwningTarget(self.getOwningTarget());
+                importTask.setLocation(self.getLocation());
+                importTask.setFile(importDir);
+                importTask.execute();
+            }
+        ]]>
+    </script>
+
+    <!--
+    The following targets can be provided to inject logic before and/or after key steps
+    of the build process:
+
+        The "init-local" target is used to initialize properties that may be personalized
+        for the local machine.
+
+            <target name="-before-init-local"/>
+            <target name="-after-init-local"/>
+
+        The "clean" target is used to clean build output from the build.dir.
+
+            <target name="-before-clean"/>
+            <target name="-after-clean"/>
+
+        The general "init" target is used to initialize all other properties, including
+        those provided by Sencha Cmd.
+
+            <target name="-before-init"/>
+            <target name="-after-init"/>
+
+        The "build" target performs the call to Sencha Cmd to build the application.
+
+            <target name="-before-build"/>
+            <target name="-after-build"/>
+    -->
+
+</project>

--- a/packages/reactor-boilerplate16/ext-react/packages/custom-ext-react-theme/examples/Readme.md
+++ b/packages/reactor-boilerplate16/ext-react/packages/custom-ext-react-theme/examples/Readme.md
@@ -1,0 +1,38 @@
+# custom-ext-react-theme/examples
+
+This folder contains example applications demonstrating this package. Each of
+these applications will be built as part of the package build:
+
+    cd /path/to/package
+    sencha package build
+
+As applications, they can also be built individually:
+
+    cd /path/to/package/examples/example-app
+    sencha app build
+
+Or you can build all examples as a group:
+
+    cd /path/to/package
+    sencha ant examples
+
+The ideal location for the example builds to reside is the `"./build"` folder:
+
+    /path/to/package/
+        src/
+        resources/
+        ...
+        examples/
+            example-app/
+            other-example/
+        ...
+        build/
+            resources/
+            examples/
+                example-app/
+                other-example/
+
+This can be specified in the `".sencha/app/build.properties"` file for the
+example applications:
+
+    build.dir=${package.build.dir}/examples/${app.name}

--- a/packages/reactor-boilerplate16/ext-react/packages/custom-ext-react-theme/licenses/Readme.md
+++ b/packages/reactor-boilerplate16/ext-react/packages/custom-ext-react-theme/licenses/Readme.md
@@ -1,0 +1,3 @@
+# custom-ext-react-theme/licenses
+
+This folder contains the supported licenses for third-party use.

--- a/packages/reactor-boilerplate16/ext-react/packages/custom-ext-react-theme/overrides/Readme.md
+++ b/packages/reactor-boilerplate16/ext-react/packages/custom-ext-react-theme/overrides/Readme.md
@@ -1,0 +1,3 @@
+# custom-ext-react-theme/overrides
+
+This folder contains overrides which will automatically be required by package users.

--- a/packages/reactor-boilerplate16/ext-react/packages/custom-ext-react-theme/overrides/init.js
+++ b/packages/reactor-boilerplate16/ext-react/packages/custom-ext-react-theme/overrides/init.js
@@ -1,0 +1,2 @@
+Ext.namespace('Ext.theme.is')['custom-ext-react-theme'] = true;
+Ext.theme.name = 'custom-ext-react-theme';

--- a/packages/reactor-boilerplate16/ext-react/packages/custom-ext-react-theme/package.json
+++ b/packages/reactor-boilerplate16/ext-react/packages/custom-ext-react-theme/package.json
@@ -1,0 +1,279 @@
+{
+    /**
+     * The name of the package.
+     */
+    "name": "custom-ext-react-theme",
+
+    "sencha": {
+        /**
+         * Alternate names for this package.
+         *
+         *    "alternateName": [],
+         */
+
+         /**
+          * The namespace of this package.
+          *
+          * As a general rule, all classes that belong to this package should be under this namespace
+          * if multiple namespaces are part of this package, set this to "".
+          */
+         "namespace": "Ext",
+
+        /**
+         * The package type.
+         *
+         * Sencha Cmd understands the following types of packages:
+         *  - code : An arbitrary package of code for use by applications or other packages.
+         *  - theme : A package to be used as an application’s theme.
+         *  - locale : A package containing localization strings or locale-specific code.
+         *  - template : A package containing one or more templates.
+         */
+        "type": "theme",
+
+        /**
+         * The parent theme package (only for "theme" package type).
+         *
+         * Themes can also use extend to inherit Sass and resources from another theme package.
+         *
+         *    "extend": "parent-theme-package",
+         */
+        "extend": "theme-material",
+
+        /**
+         * The toolkit used by this theme (only for "theme" package type).
+         *
+         * Themes can specify the toolkit they apply to ("classic" or "modern").
+         *
+         *    "toolkit": "classic",
+         */
+        "toolkit": "",
+
+         /**
+          * The author of the package.
+          *
+          * Required only if you are distributing this package through a Sencha Cmd repository,
+          * in which case it should match the name you assign to your local package repository.
+          */
+        "creator": "anonymous",
+
+        /**
+         * A summarized description of this package.
+         */
+        "summary": "Short summary",
+
+        /**
+         * A detailed description of this package.
+         */
+        "detailedDescription": "Long description of package",
+
+        /**
+         * The package version.
+         *
+         * Typically, changes to the package should come along with changes to the version.
+         * This number should be in this format: d+(.d+)*
+         */
+        "version": "1.0.0",
+
+        /**
+         * The version that users can transparently update from without requiring code changes.
+         *
+         * In addition the version property, packages can also indicate the degree to which
+         * they are backward compatible using the compatVersion property.
+         */
+        "compatVersion": "1.0.0",
+
+        /**
+         * Spec. version of this package.json file.
+         * This is set automatically by Sencha Cmd when first generating this file
+         */
+        "format": "1",
+
+        /**
+         * Additional resources used during theme slicing operations
+         */
+        "slicer": {
+            "js": [
+                {
+                    "path": "${package.dir}/sass/example/custom.js",
+                    "isWidgetManifest": true
+                }
+            ]
+        },
+
+        /**
+         * Controls the output directory.
+         */
+        "output": "${package.dir}/build",
+
+        /**
+         * Indicates whether this is a locally developed package or downloaded form a repository.
+         * Defaults to true on newly generated packages, should not be changed.
+         */
+        "local": true,
+
+        /**
+         * The theme (package) this package will use (e.g., "ext-theme-neptune", etc.).
+         * This is only needed if the built package will be used by a non-Cmd application.
+         *
+         *     "theme": "ext-theme-classic",
+         */
+
+        /**
+         * Sass configuration properties.
+         */
+        "sass" : {
+            /**
+             * The namespace to which this package's SASS corresponds. The default value of
+             * "Ext" means that the files in ./sass/src (and ./sass/var) match classes in
+             * the Ext" root namespace. In other words, "Ext.panel.Panel" maps to
+             * ./sass/src/panel/Panel.scss.
+             *
+             * To style classes from any namespace, set this to blank. If this is blank,
+             * then to style "Ext.panel.Panel" you would put SASS in
+             * ./sass/src/Ext/panel/Panel.scss.
+             */
+            "namespace": "",
+
+            /**
+             * Comma-separated list of files or folders containing extra Sass. These
+             * files are automatically included in the Sass compilation. By default this
+             * is just "etc/all.scss" to allow import directives to control the order
+             * other files are included.
+             *
+             * All "etc" files are included at the top of the Sass compilation in their
+             * dependency order:
+             *
+             *      +-------+---------+
+             *      |       | base    |
+             *      | theme +---------+
+             *      |       | derived |
+             *      +-------+---------+
+             *      | packages        |  (in package dependency order)
+             *      +-----------------+
+             *      | application     |
+             *      +-----------------+
+             */
+            "etc": [
+                "${package.dir}/sass/etc/all.scss"
+             ],
+
+            /**
+             * Comma-separated list of folders containing Sass variable definitions
+             * files. These file can also define Sass mixins for use by components.
+             *
+             * All "var" files are included after "etc" files in the Sass compilation in
+             * dependency order:
+             *
+             *      +-------+---------+
+             *      |       | base    |
+             *      | theme +---------+
+             *      |       | derived |
+             *      +-------+---------+
+             *      | packages        |  (in package dependency order)
+             *      +-----------------+
+             *      | application     |
+             *      +-----------------+
+             *
+             * The "sass/var/all.scss" file is always included at the start of the var
+             * block before any files associated with JavaScript classes.
+             */
+            "var": [
+                "${package.dir}/sass/var"
+            ],
+
+            /**
+             * Comma-separated list of folders containing Sass rule files.
+             *
+             * All "src" files are included after "var" files in the Sass compilation in
+             * dependency order (the same order as "etc"):
+             *
+             *      +-------+---------+
+             *      |       | base    |
+             *      | theme +---------+
+             *      |       | derived |
+             *      +-------+---------+
+             *      | packages        |  (in package dependency order)
+             *      +-----------------+
+             *      | application     |
+             *      +-----------------+
+             */
+            "src": [
+                "${package.dir}/sass/src"
+            ]
+        },
+
+        /**
+         * This is the comma-separated list of folders where classes reside. These
+         * classes must be explicitly required to be included in the build.
+         */
+        "classpath": [
+            "${package.dir}/src"
+        ],
+
+        /**
+         * Comma-separated string with the paths of directories or files to search. Any classes
+         * declared in these locations will be automatically required and included in the build.
+         * If any file defines an Ext JS override (using Ext.define with an "override" property),
+         * that override will in fact only be included in the build if the target class specified
+         * in the "override" property is also included.
+         */
+        "overrides": [
+            "${package.dir}/overrides"
+        ],
+
+        "example": {
+            /**
+             * One or more folders that contain example applications for this package.
+             */
+            "path": [
+                "${package.dir}/examples"
+            ]
+
+            /**
+             * You can list apps specifically.
+             *
+             *      "apps": [
+             *          "demo1",
+             *          "demo2"
+             *      ]
+             *
+             * By default, all subfolders in the path are considered example applications.
+             */
+        },
+
+        /**
+         * The framework this package will use (i.e., "ext" or "touch").
+         * This is only needed if the built package will be used by a non-Cmd application.
+         *
+         *     "framework": "ext",
+         */
+        "framework": "--name",
+
+        /**
+         * Packages can require other packages in the same way that applications can require
+         * packages.
+         *
+         * Can be specified as an array of package names or configuration objects.
+         *
+         *      "requires": [
+         *          "foo",
+         *          "bar@1.1-2.0",
+         *          {
+         *              "name": "baz"
+         *              "version": "1.5"
+         *          }
+         *      ]
+         *
+         * Can also be specified as an object:
+         *
+         *      "requires": {
+         *          "foo": "2.2",
+         *          "bar": {
+         *              "minVersion": "1.1",
+         *              "version": "2.0"
+         *          }
+         *      }
+         */
+        "requires": []
+    }
+}

--- a/packages/reactor-boilerplate16/ext-react/packages/custom-ext-react-theme/resources/Readme.md
+++ b/packages/reactor-boilerplate16/ext-react/packages/custom-ext-react-theme/resources/Readme.md
@@ -1,0 +1,3 @@
+# custom-ext-react-theme/resources
+
+This folder contains static resources (typically an `"images"` folder as well).

--- a/packages/reactor-boilerplate16/ext-react/packages/custom-ext-react-theme/sass/Readme.md
+++ b/packages/reactor-boilerplate16/ext-react/packages/custom-ext-react-theme/sass/Readme.md
@@ -1,0 +1,7 @@
+# custom-ext-react-theme/sass
+
+This folder contains SASS files of various kinds, organized in sub-folders:
+
+    custom-ext-react-theme/sass/etc
+    custom-ext-react-theme/sass/src
+    custom-ext-react-theme/sass/var

--- a/packages/reactor-boilerplate16/ext-react/packages/custom-ext-react-theme/sass/config.rb
+++ b/packages/reactor-boilerplate16/ext-react/packages/custom-ext-react-theme/sass/config.rb
@@ -1,0 +1,2 @@
+cur_dir = File.dirname(__FILE__)
+output_style = :nested

--- a/packages/reactor-boilerplate16/ext-react/packages/custom-ext-react-theme/sass/etc/Readme.md
+++ b/packages/reactor-boilerplate16/ext-react/packages/custom-ext-react-theme/sass/etc/Readme.md
@@ -1,0 +1,4 @@
+# custom-ext-react-theme/sass/etc
+
+This folder contains miscellaneous SASS files. Unlike `"custom-ext-react-theme/sass/etc"`, these files
+need to be used explicitly.

--- a/packages/reactor-boilerplate16/ext-react/packages/custom-ext-react-theme/sass/src/Readme.md
+++ b/packages/reactor-boilerplate16/ext-react/packages/custom-ext-react-theme/sass/src/Readme.md
@@ -1,0 +1,4 @@
+# custom-ext-react-theme/sass/src
+
+This folder contains SASS sources that mimic the component-class hierarchy. These files
+are gathered in to a build of the CSS based on classes that are used by the build.

--- a/packages/reactor-boilerplate16/ext-react/packages/custom-ext-react-theme/sass/var/Readme.md
+++ b/packages/reactor-boilerplate16/ext-react/packages/custom-ext-react-theme/sass/var/Readme.md
@@ -1,0 +1,3 @@
+# custom-ext-react-theme/sass/var
+
+This folder contains variable declaration files named by their component class.

--- a/packages/reactor-boilerplate16/ext-react/packages/custom-ext-react-theme/src/Readme.md
+++ b/packages/reactor-boilerplate16/ext-react/packages/custom-ext-react-theme/src/Readme.md
@@ -1,0 +1,4 @@
+# custom-ext-react-theme/src
+
+This folder contains source code that will automatically be added to the classpath when
+the package is used.

--- a/packages/reactor-boilerplate16/ext-react/workspace.json
+++ b/packages/reactor-boilerplate16/ext-react/workspace.json
@@ -1,0 +1,15 @@
+{
+    "apps": [],
+    "frameworks": {
+        "ext": "../node_modules/@extjs/ext-react"
+    },
+    "build": {
+        "dir": "${workspace.dir}/build"
+    },
+    "packages": {
+        "dir": "${workspace.dir}/packages,${workspace.dir}/../node_modules/@extjs"
+    },
+    "properties": {
+        "build.web.root": "${workspace.dir}/../"
+    }
+}


### PR DESCRIPTION
## Tiltle
Yoeman issue resolved 
## Description
Added ext-react folder to react-boilerplate15 and react-boilerplate16.
Added index.js to react-boilerplate16 to resolve yo @extjs/ext-react issue
Converted Version numbers from number to string and fixed the questions breaking issue

## Related Issue
https://sencha.jira.com/browse/REAC-321

## Motivation and Context
Using Yoeman we are creating projects which was broken and this change fixed it.

## How Has This Been Tested?
Tested this functionality by doing these changes and do npm install followed by npm link in folder generator-ext-react package
After that did yo @extjs/ext-react and started creating projects for react-boilerplate15, react-boilerplate16, react-typescript-boilerplate15 and react-typescript-boilerplate16, which went successfull.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of `extjs-reactor`.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
