### PR TITLE
2.0.x dev

### DIFF
--- a/packages/reactor-kitchensink16/src/examples/FormFields/TimeField/TimeField.js
+++ b/packages/reactor-kitchensink16/src/examples/FormFields/TimeField/TimeField.js
@@ -50,7 +50,7 @@ export default class TimeFieldExample extends Component {
                         }
                     }}
                 >
-                    <FieldSet ref="personal" title="Personal Info" defaults={{labelAlign: "placeholder"}}>
+                    <FieldSet ref="personal" title="Time Field Example" defaults={{labelAlign: "placeholder"}}>
                         <TimeField required label="Time Field" value="3:42 PM" name="time" disabled={disabled}/>
                     </FieldSet>
                     <Toolbar shadow={false} docked="bottom" layout={{ type: 'hbox', pack: 'right' }}>

--- a/packages/reactor-kitchensink16/src/examples/Gauge/DefaultGauge/DefaultGauge.js
+++ b/packages/reactor-kitchensink16/src/examples/Gauge/DefaultGauge/DefaultGauge.js
@@ -1,6 +1,6 @@
 
 import React, { Component } from 'react';
-import { SliderField, Gauge, FormPanel } from '@extjs/ext-react';
+import { SliderField, Gauge, FormPanel, ToggleField, Container } from '@extjs/ext-react';
 
 export default class DefaultGaugeExample extends Component {
 
@@ -9,20 +9,36 @@ export default class DefaultGaugeExample extends Component {
         this.state = {
             value: 40
         }
+        this.liveUpdate=false;
     }
 
     updateGauges(slider, value) {
-        this.setState({ value })
+            this.setState({ value })
+    }
+
+    changeInfo(slider, info1, info2, newVal, oldVal) {
+        if(this.liveUpdate){
+            var val = newVal[newVal.length-1];
+            this.setState({ value: val });
+        }
+    }
+
+    updateToggle(toggle, value) {
+        this.liveUpdate=value;
     }
 
     render() {
-        const { value } = this.state;
+        const { value } = this.state,
+        { liveUpdate } = this.liveUpdate;
 
         return (
-            <FormPanel shadow layout="vbox" maxWidth={350}>
-                <SliderField label="Value" onChange={this.updateGauges.bind(this)} value={value}/>
+            <FormPanel shadow layout="vbox" width={700} height={'100%'}>
+                <Container flex={1} width={'100%'} layout="hbox" maxHeight={30}>
+                    <SliderField onDrag={this.changeInfo.bind(this)} width={"70%"} onChange={this.updateGauges.bind(this)} value={value} liveUpdate={liveUpdate}/>
+                    <ToggleField onChange={this.updateToggle.bind(this)} label="Live" padding="0 0 0 20" value={liveUpdate} layout={{align:'center'}} labelAlign="right" width={"25%"} tooltip="Live Update Value Change"/>
+                </Container>
                 <Gauge flex={1} value={value}/>
-                <Gauge flex={1} value={value} ui={'green'}trackStart={180} trackLength={360}/>
+                <Gauge flex={1} value={value} ui="green" trackStart={180} trackLength={360}/>
             </FormPanel>
         )
     }

--- a/packages/reactor-kitchensink16/src/examples/Gauge/DefaultGauge/DefaultGauge.js
+++ b/packages/reactor-kitchensink16/src/examples/Gauge/DefaultGauge/DefaultGauge.js
@@ -1,6 +1,7 @@
 
 import React, { Component } from 'react';
 import { SliderField, Gauge, FormPanel, ToggleField, Container } from '@extjs/ext-react';
+import './styles.css';
 
 export default class DefaultGaugeExample extends Component {
 

--- a/packages/reactor-kitchensink16/src/examples/Gauge/DefaultGauge/styles.css
+++ b/packages/reactor-kitchensink16/src/examples/Gauge/DefaultGauge/styles.css
@@ -1,0 +1,3 @@
+.x-gauge-green .x-gauge-value{
+    fill: #0e0;
+}

--- a/packages/reactor-kitchensink16/src/examples/Gauge/NeedleGauge/NeedleGauge.js
+++ b/packages/reactor-kitchensink16/src/examples/Gauge/NeedleGauge/NeedleGauge.js
@@ -1,6 +1,6 @@
 
 import React, { Component } from 'react';
-import { SliderField, Gauge, FormPanel, Container} from '@extjs/ext-react';
+import { SliderField, Gauge, FormPanel, ToggleField, Container} from '@extjs/ext-react';
 
 Ext.require('Ext.ux.gauge.needle.Diamond');
 Ext.require('Ext.ux.gauge.needle.Arrow');
@@ -14,18 +14,35 @@ export default class NeedleGaugeExample extends Component {
         this.state = {
             value: 30
         }
+        this.liveUpdate=false;
     }
 
     updateGauges(slider, value) {
-        this.setState({ value })
+            this.setState({ value })
+    }
+
+    changeInfo(slider, info1, info2, newVal, oldVal) {
+        if(this.liveUpdate){
+            var val = newVal[newVal.length-1];
+            this.setState({ value: val });
+        }
+    }
+
+    updateToggle(toggle, value) {
+        this.liveUpdate=value;
     }
 
     render() {
-        const { value } = this.state;
+        const { value } = this.state,
+            { liveUpdate } = this.liveUpdate;
+
 
         return (
             <FormPanel shadow layout="vbox" width={850}>
-                <SliderField label="Value" width={350} onChange={this.updateGauges.bind(this)} value={value}/>
+                <Container margin={'10 0 10 0'} flex={1} width={'100%'} layout="hbox">
+                    <SliderField onDrag={this.changeInfo.bind(this)} width={"80%"} onChange={this.updateGauges.bind(this)} value={value} liveUpdate={liveUpdate}/>
+                    <ToggleField onChange={this.updateToggle.bind(this)} label="Live" padding="0 0 0 20" value={liveUpdate} layout={{align:'center'}} labelAlign="right" width={"20%"} tooltip="Live Update Value Change"/>
+                </Container>
                 <Container 
                     layout={{
                         type: 'hbox',

--- a/packages/reactor-kitchensink16/src/examples/Panels/Timepanel/TimePanel.js
+++ b/packages/reactor-kitchensink16/src/examples/Panels/Timepanel/TimePanel.js
@@ -1,14 +1,11 @@
 import React, { Component } from 'react';
 import { Container, TimePanel } from '@extjs/ext-react';
-import { mediumText } from '../../dummy';
-
-Ext.require('Ext.panel.Time');
 
 export default class TimePanelExample extends Component {
 
     render() {
         return (
-            <Container padding={Ext.os.is.Phone ? 0 : 10} layout={Ext.os.is.Phone ? 'fit' : 'auto'}>
+            <Container padding={Ext.os.is.Phone ? 0 : 10} layout="fit">
                 <TimePanel shadow/>
             </Container>
         )

--- a/packages/reactor-kitchensink16/src/examples/index.js
+++ b/packages/reactor-kitchensink16/src/examples/index.js
@@ -22,7 +22,7 @@ import ResizableHandle from './Panels/ResizableHandle/ResizableHandle';
 import CollapsiblePanel from './Panels/CollapsiblePanel/CollapsiblePanel';
 import BasicDatePanel from './Panels/BasicDatePanel/BasicDatePanel';
 import AdvancedDatePanel from './Panels/AdvancedDatePanel/AdvancedDatePanel';
-import TimePanel from './Panels/Timepanel/TimePanel';
+import TimePanel from './Panels/TimePanel/TimePanel';
 // Tabs
 
 import BasicTabs from './Tabs/BasicTabs/BasicTabs';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Did changes to Time panel and Guages UI
## Description
<!--- Describe your changes in detail -->
1.source code view option missing. - Done
2.default gauge loading issues in IE 11. - Done
3.live option missing from both gauges(default and needle). - Done
4. why personal info in timefield . we are not providing any personal info there. - Done
5.gauge bar color should different in default gauge. - Done

## Related Issue
<!--- extjs-reactor only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://sencha.jira.com/browse/REAC-320
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To resolve the gaps between extjs and ext reactor.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Did the respective changes and perform npm start. Tings are working fine
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of `extjs-reactor`.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
