### PR TITLE
TabPanel childs are not correctly destroyed and throw errors

### DIFF
--- a/packages/reactor/src/ExtJSComponent.js
+++ b/packages/reactor/src/ExtJSComponent.js
@@ -160,8 +160,12 @@ export default class ExtJSComponent extends Component {
 
             // remember the parent and position in parent for dangerouslyReplaceNodeWithMarkup
             // this not needed in fiber
-            this.el._extIndexInParent = indexInParent;
-            this.el._extParent = parentCmp;
+            if (this.el) {
+                this.el._extIndexInParent = indexInParent;
+                this.el._extParent = parentCmp;
+            } else {
+                if (this.reactorSettings.debug) console.log('destroy... no this.el', this);
+            }
         }
     }
 


### PR DESCRIPTION
when the window (reactified) is closed all Tabs inside TabPanel (exept first one) will throw an error
because this.el is null

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- extjs-reactor only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of `extjs-reactor`.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
